### PR TITLE
`Chore` Updates NuGet packages

### DIFF
--- a/AspireSwaggerUi.ApiService/AspireSwaggerUi.ApiService.csproj
+++ b/AspireSwaggerUi.ApiService/AspireSwaggerUi.ApiService.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.8" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.3" />
   </ItemGroup>
 
 </Project>

--- a/AspireSwaggerUi.AppHost/AspireSwaggerUi.AppHost.csproj
+++ b/AspireSwaggerUi.AppHost/AspireSwaggerUi.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.0.0-preview.7.24251.11" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AspireSwaggerUi.sln
+++ b/AspireSwaggerUi.sln
@@ -21,17 +21,17 @@ Global
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{968DCFC9-6382-4CFB-BE3A-3446C741DC06}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{968DCFC9-6382-4CFB-BE3A-3446C741DC06}.Debug|Any CPU.BUIld.0 = Debug|Any CPU
+		{968DCFC9-6382-4CFB-BE3A-3446C741DC06}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{968DCFC9-6382-4CFB-BE3A-3446C741DC06}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{968DCFC9-6382-4CFB-BE3A-3446C741DC06}.Release|Any CPU.BUIld.0 = Release|Any CPU
+		{968DCFC9-6382-4CFB-BE3A-3446C741DC06}.Release|Any CPU.Build.0 = Release|Any CPU
 		{81117F0C-5722-4211-BEE2-7BF3A506BD39}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{81117F0C-5722-4211-BEE2-7BF3A506BD39}.Debug|Any CPU.BUIld.0 = Debug|Any CPU
+		{81117F0C-5722-4211-BEE2-7BF3A506BD39}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{81117F0C-5722-4211-BEE2-7BF3A506BD39}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{81117F0C-5722-4211-BEE2-7BF3A506BD39}.Release|Any CPU.BUIld.0 = Release|Any CPU
+		{81117F0C-5722-4211-BEE2-7BF3A506BD39}.Release|Any CPU.Build.0 = Release|Any CPU
 		{5F5431BF-AE7F-4FD8-A3D2-D422634AEA3C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{5F5431BF-AE7F-4FD8-A3D2-D422634AEA3C}.Debug|Any CPU.BUIld.0 = Debug|Any CPU
+		{5F5431BF-AE7F-4FD8-A3D2-D422634AEA3C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5F5431BF-AE7F-4FD8-A3D2-D422634AEA3C}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{5F5431BF-AE7F-4FD8-A3D2-D422634AEA3C}.Release|Any CPU.BUIld.0 = Release|Any CPU
+		{5F5431BF-AE7F-4FD8-A3D2-D422634AEA3C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SwaggerUi.Aspire.Hosting/SwaggerUi.Aspire.Hosting.csproj
+++ b/SwaggerUi.Aspire.Hosting/SwaggerUi.Aspire.Hosting.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Aspire.Hosting" Version="8.0.0-preview.7.24251.11" />
-      <PackageReference Include="Yarp.ReverseProxy" Version="2.1.0" />
+	  <PackageReference Include="Aspire.Hosting" Version="8.2.0" />
+      <PackageReference Include="Yarp.ReverseProxy" Version="2.2.0" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR updates NuGet package dependencies to more recent version, esp. `Aspire`-related packages to `8.2.0`.

Also fixes `Configuration Manager` settings - for some reason, in the original repository, none of the projects is set to `Build` in either configuration - `Debug` or `Release`.